### PR TITLE
Implement `Arbitrary` for ASNs and IP resources.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "BSD-3-Clause"
 [dependencies]
 
 # Optional dependencies which, if included, introduce additional functionality.
+arbitrary = { version = "1", optional = true, features = ["derive"] }
 bcder = { version = "0.7.0", optional = true }
 serde = { version = "1.0.95", optional = true, features = ["derive"] }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 /// There is no way of distinguishing between IPv4 and IPv6 from just a value
 /// of this type. This information needs to be carried separately.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 struct Bits(u128);
 
 impl Bits {
@@ -159,6 +160,7 @@ impl fmt::Debug for Bits {
 /// is a IPv6 prefix with the length encoded by flipping all the bits. The
 /// value of 64 stands in for an IPv6 prefix with length 128.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 struct FamilyAndLen(u8);
 
 impl FamilyAndLen {
@@ -220,6 +222,7 @@ impl FamilyAndLen {
 /// intermediate stage (i.e. ROAs/VRPs for less-specifics making
 /// not-yet-processed more-specifics Invalid).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Prefix {
     /// The address family and prefix length all in one.
     family_and_len: FamilyAndLen,
@@ -532,6 +535,7 @@ impl fmt::Display for Prefix {
 /// that, we can safely order 'any max_len' before 'no max_len' for equal
 /// prefixes.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MaxLenPrefix {
     /// The prefix.
     prefix: Prefix,

--- a/src/asn.rs
+++ b/src/asn.rs
@@ -14,6 +14,7 @@ use bcder::decode::{self, DecodeError, Source};
 
 /// An AS number (ASN).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Asn(u32);
 
@@ -285,6 +286,7 @@ impl fmt::Display for Asn {
 /// small as it is represented internally by an ordered vec of ASNs to avoid
 /// memory overhead.
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SmallAsnSet(Vec<Asn>);
 
 impl SmallAsnSet {

--- a/src/bgpsec.rs
+++ b/src/bgpsec.rs
@@ -14,6 +14,7 @@ use crate::util::hex;
 ///
 /// This is the SHA-1 hash over the public key’s bits.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct KeyIdentifier([u8; 20]);
 
 impl KeyIdentifier {


### PR DESCRIPTION
This PR adds implementations of the _arbitrary_ crate’s `Arbitrary` trait to the `Asn` type and the various prefix-related types. This is necessary to support fuzzing.