### PR TITLE
Backport SmallAsnSet and Arbitrary impls.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.52.0, stable, beta, nightly]
+        rust: [1.56.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.56.0, stable, beta, nightly]
+        rust: [1.63.0, stable, beta, nightly]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routecore"
-version = "0.2.0"
+version = "0.2.1-dev"
 authors = ["The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>"]
 categories = ["network-programming"]
 description = "A Library with Building Blocks for BGP Routing"
@@ -12,6 +12,7 @@ license = "BSD-3-Clause"
 [dependencies]
 
 # Optional dependencies which, if included, introduce additional functionality.
+arbitrary = { version = "1", optional = true, features = ["derive"] }
 bcder = { version = "0.7.0", optional = true }
 serde = { version = "1.0.95", optional = true, features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>"]
 categories = ["network-programming"]
 description = "A Library with Building Blocks for BGP Routing"
 documentation = "https://docs.rs/routecore/"
-edition = "2018"
+edition = "2021"
+rust-version = "1.63"
 keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
This PR backports #22 and #23 from main to the 0.2 series.

This is necessary as to avoid requiring Rust 1.65 which isn’t available in all tooling just yet.