### PR TITLE
Also backport Arbitrary impl for KeyIdentifier.

### DIFF
--- a/src/bgpsec.rs
+++ b/src/bgpsec.rs
@@ -14,6 +14,7 @@ use crate::util::hex;
 ///
 /// This is the SHA-1 hash over the public key’s bits.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct KeyIdentifier([u8; 20]);
 
 impl KeyIdentifier {


### PR DESCRIPTION
This PR also backports the `Arbitrary` impl for `KeyIdentifier`.