### PR TITLE
Add some missing Serde Serialize derives

### DIFF
--- a/src/bgp/aspath.rs
+++ b/src/bgp/aspath.rs
@@ -41,6 +41,7 @@ pub type OwnedHop = Hop<Vec<u8>>;
 /// ```Hop(AS10), Hop(AS20), Hop(AS30), Hop(Set(AS40, AS50))```
 ///
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct HopPath {
     /// The hops in this HopPath.
     hops: Vec<OwnedHop>,
@@ -691,6 +692,7 @@ impl<'a, Octs: Octets> Iterator for PathSegments<'a, Octs> {
 
 /// AS_PATH Segment generic over [`Octets`].
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Segment<Octs> {
     stype: SegmentType,
     four_byte_asns: bool,
@@ -970,6 +972,7 @@ impl fmt::Display for SegmentType {
 /// variant `Segment`, which contain the entire segment and thus (possibly)
 /// multiple ASNs.
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Hop<Octs> {
     Asn(Asn),
     Segment(Segment<Octs>),

--- a/src/bgp/communities.rs
+++ b/src/bgp/communities.rs
@@ -98,7 +98,8 @@ use crate::asn::{Asn, Asn16, ParseAsnError};
 //--- Community --------------------------------------------------------------
 
 /// Standard and Extended/Large Communities variants.
-#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd )]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Community {
     Standard(StandardCommunity),
     Extended(ExtendedCommunity),
@@ -349,6 +350,7 @@ wellknown!(Wellknown,
 
 /// Conventional, RFC1997 4-byte community.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct StandardCommunity([u8; 4]);
 
 impl StandardCommunity {
@@ -523,6 +525,7 @@ impl Display for Tag {
 
 /// Extended Community as defined in RFC4360.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct ExtendedCommunity([u8; 8]);
 
 impl ExtendedCommunity {
@@ -907,6 +910,7 @@ impl Display for ExtendedCommunity {
 
 /// IPv6 Extended Community as defined in RFC5701.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Ipv6ExtendedCommunity([u8; 20]);
 
 
@@ -1023,6 +1027,7 @@ impl Display for Ipv6ExtendedCommunity {
 
 /// Large Community as defined in RFC8092.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd )]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct LargeCommunity([u8; 12]);
 
 impl LargeCommunity {

--- a/src/bgp/message/update.rs
+++ b/src/bgp/message/update.rs
@@ -27,6 +27,7 @@ const COFF: usize = 19; // XXX replace this with .skip()'s?
 
 /// BGP UPDATE message, variant of the [`Message`] enum.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct UpdateMessage<Octs: Octets> {
     octets: Octs,
     session_config: SessionConfig,
@@ -520,6 +521,7 @@ impl<Octs: Octets> UpdateMessage<Octs> {
 /// BGP OPEN messages when the session was established.
 ///
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct SessionConfig {
     pub four_octet_asn: FourOctetAsn,
     pub add_path: AddPath,
@@ -588,6 +590,7 @@ impl SessionConfig {
 
 /// Indicates whether this session is Four Octet capable.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum FourOctetAsn {
     Enabled,
     Disabled,
@@ -595,6 +598,7 @@ pub enum FourOctetAsn {
 
 /// Indicates whether AddPath is enabled for this session.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum AddPath {
     Enabled,
     Disabled,

--- a/src/bgp/message/update.rs
+++ b/src/bgp/message/update.rs
@@ -1266,6 +1266,7 @@ impl<'a, Ref: Octets> IntoIterator for PathAttributes<'a, Ref> {
 //--- Aggregator -------------------------------------------------------------
 /// Path Attribute (7).
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Aggregator {
     asn: Asn,
     speaker: Ipv4Addr,

--- a/src/bgp/types.rs
+++ b/src/bgp/types.rs
@@ -30,6 +30,7 @@ typeenum!(
 
 /// BGP Origin types as used in BGP UPDATE messages.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum OriginType {
     Igp,
     Egp,

--- a/src/bgp/types.rs
+++ b/src/bgp/types.rs
@@ -93,6 +93,7 @@ impl std::fmt::Display for MultiExitDisc {
 
 /// Wrapper for the 4 byte Local Preference value in path attributes.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct LocalPref(pub u32);
 
 impl std::fmt::Display for LocalPref {

--- a/src/bgp/types.rs
+++ b/src/bgp/types.rs
@@ -83,6 +83,7 @@ typeenum!(
 
 /// Wrapper for the 4 byte Multi-Exit Discriminator in path attributes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct MultiExitDisc(pub u32);
 
 impl std::fmt::Display for MultiExitDisc {


### PR DESCRIPTION
This is just the minimum needed to make Serialization work for the affected types. No attempt is made to customize the serialization behaviour to match any particular desired output structure, Serde defaults are used. 