### PR TITLE
type enums everywhere

### DIFF
--- a/src/bgp/message/mod.rs
+++ b/src/bgp/message/mod.rs
@@ -89,12 +89,14 @@ impl<Octs: Octets> Message<Octs> {
 typeenum!(
 /// BGP Message types.
     MsgType, u8,
-    1 => Open,
-    2 => Update,
-    3 => Notification,
-    4 => Keepalive,
-    5 => RouteRefresh, // RFC2918
-    //6 => //Capability, // draft-ietf-idr-dynamic-cap
+    {
+        1 => Open,
+        2 => Update,
+        3 => Notification,
+        4 => Keepalive,
+        5 => RouteRefresh, // RFC2918
+        //6 => //Capability, // draft-ietf-idr-dynamic-cap
+    }
 );
 
 impl<Octs: Octets> Message<Octs> {

--- a/src/bgp/message/open.rs
+++ b/src/bgp/message/open.rs
@@ -635,38 +635,44 @@ typeenum!(
 /// BGP Capability type, as per
 /// <https://www.iana.org/assignments/capability-codes/capability-codes.xhtml>.
     CapabilityType, u8,
-    0 => Reserved,
-    1 => MultiProtocol,
-    2 => RouteRefresh,
-    3 => OutboundRouteFiltering,
-    5 => ExtendedNextHop,
-    6 => ExtendedMessage,
-    8 => MultipleLabels,
-    9 => BgpRole,
-    //10..=63 => Unassigned,
-    64 => GracefulRestart,
-    65 => FourOctetAsn,
-    66 => DeprecatedDynamicCapability,
-    67 => DynamicCapability,
-    68 => Multisession,
-    69 => AddPath,
-    70 => EnhancedRouteRefresh,
-    71 => LongLivedGracefulRestart,
-    73 => FQDN,
-    128 => PrestandardRouteRefresh,
-    130 => PrestandardOutboundRouteFiltering,
-    131 => PrestandardMultisession,
+    {
+        0 => Reserved,
+        1 => MultiProtocol,
+        2 => RouteRefresh,
+        3 => OutboundRouteFiltering,
+        5 => ExtendedNextHop,
+        6 => ExtendedMessage,
+        8 => MultipleLabels,
+        9 => BgpRole,
+        //10..=63 => Unassigned,
+        64 => GracefulRestart,
+        65 => FourOctetAsn,
+        66 => DeprecatedDynamicCapability,
+        67 => DynamicCapability,
+        68 => Multisession,
+        69 => AddPath,
+        70 => EnhancedRouteRefresh,
+        71 => LongLivedGracefulRestart,
+        73 => FQDN,
+        128 => PrestandardRouteRefresh,
+        130 => PrestandardOutboundRouteFiltering,
+        131 => PrestandardMultisession,
+    }
 );
 
 typeenum!(
 /// BGP OPEN Optional Parameter type, as per
 /// <https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-11>.
     OptionalParameterType, u8,
-    0 => Reserved,
-    1 => Authentication,
-    2 => Capabilities,
-    //3..=254 => Unassigned,
-    255 => ExtendedLength
+    {
+        0 => Reserved,
+        1 => Authentication,
+        2 => Capabilities,
+        255 => ExtendedLength
+    },
+    {
+        3..=254 => Unassigned,
+    }
 );
 
 

--- a/src/bgp/types.rs
+++ b/src/bgp/types.rs
@@ -8,25 +8,27 @@ use serde::{Serialize, Deserialize};
 
 typeenum!(
 /// AFI as used in BGP OPEN and UPDATE messages.
-    AFI, u16,
-    1 => Ipv4,
-    2 => Ipv6,
-    25 => L2Vpn,
-);
+        AFI, u16,
+        {
+            1 => Ipv4,
+            2 => Ipv6,
+            25 => L2Vpn
+        });
 
 typeenum!(
 /// SAFI as used in BGP OPEN and UPDATE messages.
     SAFI, u8,
-    1 => Unicast,
-    2 => Multicast,
-    4 => MplsUnicast,
-    65 => Vpls,
-    70 => Evpn,
-    128 => MplsVpnUnicast,
+    {
+        1 => Unicast,
+        2 => Multicast,
+        4 => MplsUnicast,
+        65 => Vpls,
+        70 => Evpn,
+        128 => MplsVpnUnicast,
     132 => RouteTarget,
     133 => FlowSpec,
-    134 => FlowSpecVpn,
-);
+    134 => FlowSpecVpn
+    });
 
 /// BGP Origin types as used in BGP UPDATE messages.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -55,30 +57,32 @@ typeenum!(
 /// As per:
 /// <https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2>
     PathAttributeType, u8,
-    0 => Reserved,
-    1 => Origin,
-    2 => AsPath,
-    3 => NextHop,
-    4 => MultiExitDisc,
-    5 => LocalPref,
-    6 => AtomicAggregate,
-    7 => Aggregator,
-    8 => Communities,
-    9 => OriginatorId,
-    10 => ClusterList,
-    14 => MpReachNlri,
-    15 => MpUnreachNlri,
-    16 => ExtendedCommunities,
-    17 => As4Path,
-    18 => As4Aggregator,
-    20 => Connector,
-    21 => AsPathLimit,
-    22 => PmsiTunnel,
-    25 => Ipv6ExtendedCommunities,
-    32 => LargeCommunities,
-    33 => BgpsecAsPath,
-    128 => AttrSet,
-    255 => RsrvdDevelopment,
+    {
+        0 => Reserved,
+        1 => Origin,
+        2 => AsPath,
+        3 => NextHop,
+        4 => MultiExitDisc,
+        5 => LocalPref,
+        6 => AtomicAggregate,
+        7 => Aggregator,
+        8 => Communities,
+        9 => OriginatorId,
+        10 => ClusterList,
+        14 => MpReachNlri,
+        15 => MpUnreachNlri,
+        16 => ExtendedCommunities,
+        17 => As4Path,
+        18 => As4Aggregator,
+        20 => Connector,
+        21 => AsPathLimit,
+        22 => PmsiTunnel,
+        25 => Ipv6ExtendedCommunities,
+        32 => LargeCommunities,
+        33 => BgpsecAsPath,
+        128 => AttrSet,
+        255 => RsrvdDevelopment
+    }
 );
 
 /// Wrapper for the 4 byte Multi-Exit Discriminator in path attributes.

--- a/src/bmp/message.rs
+++ b/src/bmp/message.rs
@@ -529,9 +529,11 @@ typeenum!(
 typeenum!(
     /// Specify which RIB the contents of a message originated from.
     RibType, u8,
-    {0 => AdjRibIn,
-    1 => AdjRibOut
-});
+    {
+        0 => AdjRibIn,
+        1 => AdjRibOut
+    }
+);
 
 
 //--- Specific Message types -------------------------------------------------

--- a/src/bmp/message.rs
+++ b/src/bmp/message.rs
@@ -75,14 +75,16 @@ typeenum!(
     /// Types of BMP messages as defined in
     /// [RFC7854](https://datatracker.ietf.org/doc/html/rfc7854).
     MessageType, u8,
-    0 => RouteMonitoring,
-    1 => StatisticsReport,
-    2 => PeerDownNotification,
-    3 => PeerUpNotification,
-    4 => InitiationMessage,
-    5 => TerminationMessage,
-    6 => RouteMirroring,
-);
+    {
+        0 => RouteMonitoring,
+        1 => StatisticsReport,
+        2 => PeerDownNotification,
+        3 => PeerUpNotification,
+        4 => InitiationMessage,
+        5 => TerminationMessage,
+        6 => RouteMirroring,
+        }
+    );
 
 
 impl<Octets: AsRef<[u8]>> AsRef<[u8]> for InitiationMessage<Octets> {

--- a/src/bmp/message.rs
+++ b/src/bmp/message.rs
@@ -373,12 +373,7 @@ impl<Octets: AsRef<[u8]>> PerPeerHeader<Octets> {
     /// Returns the peer type as defined in
     /// [RFC7854](https://datatracker.ietf.org/doc/html/rfc7854#section-10.2).
     pub fn peer_type(&self) -> PeerType {
-        match self.octets.as_ref()[0] {
-            0 => PeerType::GlobalInstance,
-            1 => PeerType::RdInstance,
-            2 => PeerType::LocalInstance,
-            _ => PeerType::Undefined,
-        }
+        self.octets.as_ref()[0].into()
     }
 
     //  0 1 2 3 4 5 6 7
@@ -511,22 +506,26 @@ impl<Octets: AsRef<[u8]>> PartialEq for PerPeerHeader<Octets> {
     }
 }
 
-/// The three peer types as defined in
-/// [RFC7854](https://datatracker.ietf.org/doc/html/rfc7854#section-4.2).
-#[derive(Debug, Hash, Eq, PartialEq)]
-pub enum PeerType {
-    GlobalInstance,
-    RdInstance,
-    LocalInstance,
-    Undefined,
-}
+typeenum!(
+    /// The peer types as defined in
+    /// https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#peer-types
+    PeerType, u8,
+    0 => GlobalInstance,
+    1 => RdInstance,
+    2 => LocalInstance,
+    3 => LocalRibInstance;
+    4..=250 => Unassigned;
+    251..=254 => Experimental;
+    255 => Reserved
+);
 
-/// Specify which RIB the contents of a message originated from.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub enum RibType {
-    AdjRibIn,
-    AdjRibOut,
-}
+
+typeenum!(
+    /// Specify which RIB the contents of a message originated from.
+    RibType, u8,
+    0 => AdjRibIn,
+    1 => AdjRibOut
+);
 
 
 //--- Specific Message types -------------------------------------------------
@@ -1068,14 +1067,7 @@ impl<'a> InformationTlv<'a> {
 
     /// Returns the `InformationTlvType` for this TLV.
     pub fn typ(&self) -> InformationTlvType {
-        match u16::from_be_bytes(self.octets[0..=1].try_into().unwrap()) {
-            0 => InformationTlvType::String,
-            1 => InformationTlvType::SysDesc,
-            2 => InformationTlvType::SysName,
-            3 => InformationTlvType::VrfTableName,
-            4 => InformationTlvType::AdminLabel,
-            u => InformationTlvType::Undefined(u)
-        }
+        InformationTlvType::from(u16::from_be_bytes(self.octets[0..=1].try_into().unwrap()))
     }
 
     /// Returns the length of the value.
@@ -1105,19 +1097,19 @@ impl<'a> Display for InformationTlv<'a> {
 
 }
 
-/// Types of Information TLVs.
-///
-/// See also
-/// <https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#initiation-peer-up-tlvs>
-#[derive(Debug, Eq, PartialEq)]
-pub enum InformationTlvType {
-    String,         // type 0
-    SysDesc,        // type 1
-    SysName,        // type 2
-    VrfTableName,   // type 3, RFC 9069
-    AdminLabel,     // type 4, RFC 8671
-    Undefined(u16),
-}
+typeenum!(
+    /// Types of Information TLVs.
+    ///
+    /// See also
+    /// <https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#initiation-peer-up-tlvs>
+    InformationTlvType, u16,
+    0 => String,
+    1 => SysDesc,
+    2 => SysName,
+    3 => VrfTableName,
+    4 => AdminLabel;
+    5.. => Undefined
+);
 
 /// Iterator over `InformationTlv`'s.
 pub struct InformationTlvIter<'a> {

--- a/src/bmp/message.rs
+++ b/src/bmp/message.rs
@@ -510,22 +510,26 @@ typeenum!(
     /// The peer types as defined in
     /// https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#peer-types
     PeerType, u8,
-    0 => GlobalInstance,
-    1 => RdInstance,
-    2 => LocalInstance,
-    3 => LocalRibInstance;
-    4..=250 => Unassigned;
-    251..=254 => Experimental;
-    255 => Reserved
+    {
+        0 => GlobalInstance,
+        1 => RdInstance,
+        2 => LocalInstance,
+        3 => LocalRibInstance,
+        255 => Reserved
+    },
+    {
+        4..=250 => Unassigned,
+        251..=254 => Experimental,
+    }
 );
 
 
 typeenum!(
     /// Specify which RIB the contents of a message originated from.
     RibType, u8,
-    0 => AdjRibIn,
+    {0 => AdjRibIn,
     1 => AdjRibOut
-);
+});
 
 
 //--- Specific Message types -------------------------------------------------
@@ -1103,12 +1107,16 @@ typeenum!(
     /// See also
     /// <https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#initiation-peer-up-tlvs>
     InformationTlvType, u16,
-    0 => String,
-    1 => SysDesc,
-    2 => SysName,
-    3 => VrfTableName,
-    4 => AdminLabel;
-    5.. => Undefined
+    { 
+        0 => String,
+        1 => SysDesc,
+        2 => SysName,
+        3 => VrfTableName,
+        4 => AdminLabel,
+    },
+    {
+        5.. => Undefined,
+    }
 );
 
 /// Iterator over `InformationTlv`'s.

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -18,45 +18,72 @@
 /// and `L2Vpn`. On this enum, the [`From`] (for conversion between the
 /// variants and `u16`) and [`std::fmt::Display`] traits are implemented.
 ///
+/// You can also specify ranges as like so:
+/// 
+/// ```rust
+/// typeenum!(
+///     PeerType, u8,
+///     0 => GlobalInstance,
+///     1 => RdInstance,
+///     2 => LocalInstance,
+///     3 => LocalRibInstance;
+///     4..=250 => Unassigned;
+///     251..=254 => Experimental;
+///     255 => Reserved
+/// );
+/// ```
+/// Note that match lines with ranges are separated by semi-colons, rather
+/// than by commas. Range variants have a data field with the specified value.
+/// Specifying an half-open range to the right or specifying the matches
+/// exhaustively will disable the default `Unimplemented` variant.
 #[macro_export]
 macro_rules! typeenum {
-    ($(#[$attr:meta])* $name:ident, $ty:ty, $($x:expr => $y:ident),+ $(,)*) => {
-        $(#[$attr])*
-        #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
-        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-        pub enum $name {
-            $($y),+,
-            Unimplemented($ty),
-        }
+    ($(#[$attr:meta])* $name:ident, 
+        $ty:ty, 
+        $($x:expr => $y:ident),+ $(,)* 
+        $(;$x1:pat => $y1:ident)*) => {
+            $(#[$attr])*
+            #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+            #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+            pub enum $name {
+                $($y),+,
+                $($y1($ty),)?
+                Unimplemented($ty),
+            }
 
-        impl From<$ty> for $name {
-            fn from(f: $ty) -> $name {
-                match f {
-                    $($x => $name::$y,)+
-                    u => $name::Unimplemented(u),
+            impl From<$ty> for $name {
+                #[allow(unreachable_patterns)]
+                fn from(f: $ty) -> $name {
+                    match f {
+                        $($x => $name::$y,)+
+                        $($x1 => $name::$y1(f),)?
+                        u => $name::Unimplemented(u),
+                    }
+                }
+            }
+
+            impl From<$name> for $ty {
+                fn from(s: $name) -> $ty {
+                    match s {
+                        $($name::$y => $x,)+
+                        $($name::$y1(u) => u,)?
+                        $name::Unimplemented(u) => u,
+                    }
+                }
+
+            }
+
+            impl std::fmt::Display for $name {
+                fn fmt(&self, f: &mut std::fmt::Formatter)
+                    -> Result<(), std::fmt::Error>
+                {
+                    match self {
+                        $($name::$y => write!(f, stringify!($y))),+,
+                        $($name::$y1(u) => write!(f, "{} ({})", stringify!($u), u),)?
+                        $name::Unimplemented(u) =>
+                            write!(f, "unknown-{}-{}", stringify!($name), u)
+                    }
                 }
             }
         }
-
-        impl From<$name> for $ty {
-            fn from(s: $name) -> $ty {
-                match s {
-                    $($name::$y => $x,)+
-                    $name::Unimplemented(u) => u,
-                }
-            }
-
-        }
-		impl std::fmt::Display for $name {
-			fn fmt(&self, f: &mut std::fmt::Formatter)
-				-> Result<(), std::fmt::Error>
-			{
-				match self {
-                    $($name::$y => write!(f, stringify!($y))),+,
-					$name::Unimplemented(u) =>
-                        write!(f, "unknown-{}-{}", stringify!($name), u)
-				}
-			}
-		}
-    }
 }

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -39,10 +39,11 @@
 ///     }
 /// );
 /// ```
-/// Note that match lines with ranges are separated by semi-colons, rather
-/// than by commas. Range variants have a data field with the specified value.
-/// Specifying an half-open range to the right or specifying the matches
-/// exhaustively will disable the default `Unimplemented` variant.
+/// Note that match lines with ranges are come in a separate block after
+/// the block with single selector values. Range variants have a data
+/// field with the specified value. Specifying an half-open range to the
+/// right or specifying the matches exhaustively will disable the default 
+/// `Unimplemented` variant.
 #[macro_export]
 macro_rules! typeenum {
     ( $(#[$attr:meta])* 

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -24,6 +24,10 @@
 /// You can also specify ranges as like so:
 /// 
 /// ```rust
+/// # #[cfg(feature = "serde")]
+/// # use serde::{Serialize, Deserialize};
+/// # #[macro_use] extern crate routecore;
+/// # fn main() {
 /// typeenum!(
 ///     PeerType, u8,
 ///     {
@@ -31,13 +35,14 @@
 ///         1 => RdInstance,
 ///         2 => LocalInstance,
 ///         3 => LocalRibInstance,
-///     }
+///     },
 ///     {
 ///         4..=250 => Unassigned,
 ///         251..=254 => Experimental,
-///         255 => Reserved
+///         255 => Reserved,
 ///     }
 /// );
+/// # }
 /// ```
 /// Note that match lines with ranges are come in a separate block after
 /// the block with single selector values. Range variants have a data


### PR DESCRIPTION
- Expanded the typeenum macro to allow for ranges with data-field variants
- Use the enum instead of manual impl for several types in bmp