### PR TITLE
Enhanced BGP NOTIFICATION support

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -404,6 +404,15 @@ impl Prefix {
         self.bits.into_int()
             ==  other.bits.into_int() & !(u128::MAX >> self.len())
     }
+
+    /// Returns `true` if the prefix contains `addr` .
+    pub fn contains(self, addr: IpAddr) -> bool {
+        let p2 = match addr {
+            IpAddr::V4(a) => Prefix::new_v4(a, 32),
+            IpAddr::V6(a) => Prefix::new_v6(a, 128)
+        }.unwrap();
+        self.covers(p2)
+    }
 }
 
 //--- PartialOrd and Ord

--- a/src/bgp/message/nlri.rs
+++ b/src/bgp/message/nlri.rs
@@ -24,13 +24,13 @@ impl NextHop {
             (16, AFI::Ipv6, SAFI::Unicast | SAFI::MplsUnicast) =>
                 //NextHop::Ipv6
                 parser.advance(16)?,
-            (32, AFI::Ipv6, SAFI::Unicast) =>
+            (32, AFI::Ipv6, SAFI::Unicast | SAFI::Multicast) =>
                 //NextHop::Ipv6LL
                 parser.advance(16 + 16)?,
             (24, AFI::Ipv6, SAFI::MplsVpnUnicast) =>
                 //NextHop::Ipv6MplsVpnUnicast
                 parser.advance(8 + 16)?,
-            (4, AFI::Ipv4, SAFI::Unicast | SAFI::MplsUnicast ) =>
+            (4, AFI::Ipv4, SAFI::Unicast | SAFI::Multicast | SAFI::MplsUnicast ) =>
                 //NextHop::Ipv4
                 parser.advance(4)?,
             (12, AFI::Ipv4, SAFI::MplsVpnUnicast) =>
@@ -63,7 +63,7 @@ impl NextHop {
         let res = match (len, afi, safi) {
             (16, AFI::Ipv6, SAFI::Unicast | SAFI::MplsUnicast) =>
                 NextHop::Ipv6(parse_ipv6addr(parser)?),
-            (32, AFI::Ipv6, SAFI::Unicast) =>
+            (32, AFI::Ipv6, SAFI::Unicast | SAFI::Multicast) =>
                 NextHop::Ipv6LL(
                     parse_ipv6addr(parser)?,
                     parse_ipv6addr(parser)?
@@ -73,7 +73,7 @@ impl NextHop {
                     RouteDistinguisher::parse(parser)?,
                     parse_ipv6addr(parser)?
                 ),
-            (4, AFI::Ipv4, SAFI::Unicast | SAFI::MplsUnicast ) =>
+            (4, AFI::Ipv4, SAFI::Unicast | SAFI::Multicast | SAFI::MplsUnicast ) =>
                 NextHop::Ipv4(parse_ipv4addr(parser)?),
             (12, AFI::Ipv4, SAFI::MplsVpnUnicast) =>
                 NextHop::Ipv4MplsVpnUnicast(

--- a/src/bgp/message/notification.rs
+++ b/src/bgp/message/notification.rs
@@ -261,22 +261,28 @@ impl Details {
 
 // See RFCs 4271 4486 8203 9003
 
-typeenum!(ErrorCode, u8, 
-    0 => Reserved,
-    1 => MessageHeaderError,
-    2 => OpenMessageError,
-    3 => UpdateMessageError,
-    4 => HoldTimerExpired,
-    5 => FiniteStateMachineError,
-    6 => Cease,
-    7 => RouteRefreshMessageError,
+typeenum!(
+    ErrorCode, u8,
+    {
+        0 => Reserved,
+        1 => MessageHeaderError,
+        2 => OpenMessageError,
+        3 => UpdateMessageError,
+        4 => HoldTimerExpired,
+        5 => FiniteStateMachineError,
+        6 => Cease,
+        7 => RouteRefreshMessageError,
+    }
 );
 
-typeenum!(MessageHeaderSubcode, u8,
-    0 => Unspecific,
-    1 => ConnectionNotSynchronized,
-    2 => BadMessageLength, // data: u16 bad length
-    3 => BadMessageType, // data: u8 bad type
+typeenum!(
+    MessageHeaderSubcode, u8,
+    {
+        0 => Unspecific,
+        1 => ConnectionNotSynchronized,
+        2 => BadMessageLength, // data: u16 bad length
+        3 => BadMessageType, // data: u8 bad type
+    }
 );
 
 impl From<MessageHeaderSubcode> for Details {
@@ -285,19 +291,22 @@ impl From<MessageHeaderSubcode> for Details {
     }
 }
 
-typeenum!(OpenMessageSubcode, u8, 
-    0 => Unspecific,
-    1 => UnsupportedVersionNumber, // only one with data: u16 version number
-    2 => BadPeerAs,
-    3 => BadBgpIdentifier,
-    4 => UnsupportedOptionalParameter,
-    5 => Deprecated5, // was: authentication failure
-    6 => UnacceptableHoldTime,
-    7 => UnsupportedCapability,
-    8 => Deprecated8, // 8-10 deprecated because of 'improper use', rfc9234
-    9 => Deprecated9,
-    10 => Deprecated10,
-    11 => RoleMismatch,
+typeenum!(
+    OpenMessageSubcode, u8,
+    {
+        0 => Unspecific,
+        1 => UnsupportedVersionNumber, // only one with data: u16 version number
+        2 => BadPeerAs,
+        3 => BadBgpIdentifier,
+        4 => UnsupportedOptionalParameter,
+        5 => Deprecated5, // was: authentication failure
+        6 => UnacceptableHoldTime,
+        7 => UnsupportedCapability,
+        8 => Deprecated8, // 8-10 deprecated because of 'improper use', rfc9234
+        9 => Deprecated9,
+        10 => Deprecated10,
+        11 => RoleMismatch,
+    }
 );
 
 impl From<OpenMessageSubcode> for Details {
@@ -306,19 +315,22 @@ impl From<OpenMessageSubcode> for Details {
     }
 }
 
-typeenum!(UpdateMessageSubcode, u8,
-    0 => Unspecific,
-    1 => MalformedAttributeList, // no data
-    2 => UnrecognizedWellknownAttribute, // data: unrecognized attribute
-    3 => MissingWellknownAttribute, // data: typecode of missing attribute
-    4 => AttributeFlagsError, // data: erroneous attribute (t, l, v)
-    5 => AttributeLengthError, // data: erroneous attribute (t, l, v)
-    6 => InvalidOriginAttribute, // data: erroneous attribute (t, l, v)
-    7 => Deprecated7, // was: AS routing loop, rfc1771
-    8 => InvalidNextHopAttribute, // data: erroneous attribute (t, l, v)
-    9 => OptionalAttributeError, // data: erroneous attribute (t, l, v)
-    10 => InvalidNetworkField, // no data
-    11 => MalformedAsPath, // no data
+typeenum!(
+    UpdateMessageSubcode, u8,
+    {
+        0 => Unspecific,
+        1 => MalformedAttributeList, // no data
+        2 => UnrecognizedWellknownAttribute, // data: unrecognized attribute
+        3 => MissingWellknownAttribute, // data: typecode of missing attribute
+        4 => AttributeFlagsError, // data: erroneous attribute (t, l, v)
+        5 => AttributeLengthError, // data: erroneous attribute (t, l, v)
+        6 => InvalidOriginAttribute, // data: erroneous attribute (t, l, v)
+        7 => Deprecated7, // was: AS routing loop, rfc1771
+        8 => InvalidNextHopAttribute, // data: erroneous attribute (t, l, v)
+        9 => OptionalAttributeError, // data: erroneous attribute (t, l, v)
+        10 => InvalidNetworkField, // no data
+        11 => MalformedAsPath, // no data
+    }
 );
 
 impl From<UpdateMessageSubcode> for Details {
@@ -327,11 +339,14 @@ impl From<UpdateMessageSubcode> for Details {
     }
 }
 
-typeenum!(FiniteStateMachineSubcode, u8, 
-    0 => UnspecifiedError,
-    1 => UnexpectedMessageInOpenSentState, // data: u8 of message type
-    2 => UnexpectedMessageInOpenConfirmState, // data: u8 of message type
-    3 => UnexpectedMessageInEstablishedState, // data: u8 of message type
+typeenum!(
+    FiniteStateMachineSubcode, u8,
+    {
+        0 => UnspecifiedError,
+        1 => UnexpectedMessageInOpenSentState, // data: u8 of message type
+        2 => UnexpectedMessageInOpenConfirmState, // data: u8 of message type
+        3 => UnexpectedMessageInEstablishedState, // data: u8 of message type
+    }
 );
 
 impl From<FiniteStateMachineSubcode> for Details {
@@ -340,18 +355,21 @@ impl From<FiniteStateMachineSubcode> for Details {
     }
 }
 
-typeenum!(CeaseSubcode, u8,
-    0 => Reserved,
-    1 => MaximumPrefixesReached,
-    2 => AdministrativeShutdown,
-    3 => PeerDeconfigured,
-    4 => AdministrativeReset,
-    5 => ConnectionRejected,
-    6 => OtherConfigurationChange,
-    7 => ConnectionCollisionResolution,
-    8 => OutOfResources,
-    9 => HardReset,
-    10 => BfdDown,
+typeenum!(
+    CeaseSubcode, u8,
+    {
+        0 => Reserved,
+        1 => MaximumPrefixesReached,
+        2 => AdministrativeShutdown,
+        3 => PeerDeconfigured,
+        4 => AdministrativeReset,
+        5 => ConnectionRejected,
+        6 => OtherConfigurationChange,
+        7 => ConnectionCollisionResolution,
+        8 => OutOfResources,
+        9 => HardReset,
+        10 => BfdDown,
+    }
 );
 
 impl From<CeaseSubcode> for Details {
@@ -361,9 +379,12 @@ impl From<CeaseSubcode> for Details {
 }
 
 
-typeenum!(RouteRefreshMessageSubcode, u8, 
-    0 => Reserved,
-    1 => InvalidMessageLength, // data: complete RouteRefresh message
+typeenum!(
+    RouteRefreshMessageSubcode, u8,
+    {
+        0 => Reserved,
+        1 => InvalidMessageLength, // data: complete RouteRefresh message
+    }
 );
 
 impl From<RouteRefreshMessageSubcode> for Details {

--- a/src/bgp/message/notification.rs
+++ b/src/bgp/message/notification.rs
@@ -1,5 +1,5 @@
 use log::warn;
-use octseq::{Octets, OctetsBuilder, Parser, ShortBuf};
+use octseq::{Octets, OctetsBuilder, Parser};
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize}; // for typeenum! macro
 
@@ -158,7 +158,7 @@ where Infallible: From<<Target as OctetsBuilder>::AppendError> {
         let _ = target.append_slice(&subcode.raw());
 
         if let Some(data) = data {
-            let _ = target.append_slice(&data.as_ref());
+            let _ = target.append_slice(data.as_ref());
         }
 
         Ok(target)
@@ -172,7 +172,7 @@ impl NotificationBuilder<Vec<u8>> {
         subcode: Details,
         data: Option<D>
     ) -> Result<Vec<u8>, NotificationBuildError> {
-        Ok(Self::from_target(Vec::with_capacity(21), /*code,*/ subcode, data)?)
+        Self::from_target(Vec::with_capacity(21), /*code,*/ subcode, data)
     }
 }
 

--- a/src/bgp/message/open.rs
+++ b/src/bgp/message/open.rs
@@ -507,7 +507,7 @@ impl<Octs: Octets> Capability<Octs> {
 // Also see
 // <https://www.iana.org/assignments/capability-codes/capability-codes.xhtml>
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Capability<Octs> {
     octets: Octs,
 }

--- a/src/bgp/message/update.rs
+++ b/src/bgp/message/update.rs
@@ -811,8 +811,8 @@ impl<'a> PathAttribute<'a, [u8]> {
                 }
             },
             PathAttributeType::Aggregator => {
-                let mut pp = parser.parse_parser(len)?;
-                Aggregator::check(&mut pp, config)?;
+                let pp = parser.parse_parser(len)?;
+                Aggregator::check(&pp, config)?;
             },
             PathAttributeType::Communities => {
                 let mut pp = parser.parse_parser(len)?;
@@ -1392,7 +1392,7 @@ impl<Octs: Octets> Iterator for LargeCommunityIter<Octs> {
 }
 
 impl Aggregator {
-    fn check(parser: &mut Parser<[u8]>, config: SessionConfig)
+    fn check(parser: &Parser<[u8]>, config: SessionConfig)
         -> Result<(), ParseError>
     {
         let len = parser.remaining(); // XXX is this always correct?

--- a/src/bmp/message.rs
+++ b/src/bmp/message.rs
@@ -1797,6 +1797,8 @@ mod tests {
 
     #[test]
     fn peer_down_notification() {
+        use crate::bgp::message::notification::CeaseSubcode;
+
         // BMP PeerDownNotification type 3, containing a BGP NOTIFICATION.
         let buf = vec![
             0x03, 0x00, 0x00, 0x00, 0x46, 0x02, 0x00, 0x80,
@@ -1815,8 +1817,10 @@ mod tests {
         assert_eq!(bmp.fsm(), None);
 
         let bgp_notification = bmp.notification().unwrap();
-        assert_eq!(bgp_notification.code(), 6);
-        assert_eq!(bgp_notification.subcode(), 2);
+        assert_eq!(
+            bgp_notification.details(),
+            CeaseSubcode::AdministrativeShutdown.into()
+        );
     }
 
 


### PR DESCRIPTION
This PR adds several things required for proper BGP session handling:

* most notably parsing and creation of NOTIFICATION PDUs;
* To enable flexible local configuration, a `fn contains()` method on `addr::Prefix` is introduced