### PR TITLE
Tidy up Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,28 +11,22 @@ keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
 
 [dependencies]
-
 # Optional dependencies which, if included, introduce additional functionality.
 arbitrary = { version = "1", optional = true, features = ["derive"] }
-bcder = { version = "0.7.0", optional = true }
-serde = { version = "1.0.95", optional = true, features = ["derive"] }
-
-
-bytes = { version = "1.1.0", optional = true }
-chrono = { version = "0.4", optional = true }
-const-str = { version = "0.5.3", optional = true, features = ["case"] }
-log = { version = "0.4.17", optional = true }
-
-octseq = { version = "0.3.1", features = ["bytes"], optional = true }
-tokio = { version = "1", features = ["sync", "rt"], optional = true }
+#bcder = { version = "0.7", optional = true }
+bytes       = { version = "1", optional = true }
+chrono      = { version = "0.4.20", optional = true }
+const-str   = { version = "0.5", optional = true, features = ["case"] }
+log         = { version = "0.4.4", optional = true }
+octseq      = { version = "0.3.1", features = ["bytes"], optional = true }
+serde       = { version = "1.0.103", optional = true, features = ["derive"] }
+tokio       = { version = "1", features = ["sync", "rt"], optional = true }
 
 [dev-dependencies]
 serde_test      = "1.0"
 memmap2         = "0.6"
 
 [features]
-default = ["octseq"]
+default = []
 bgp = ["bytes", "log", "octseq", "const-str"]
-bmp = ["bgp", "bytes", "chrono", "log", "octseq"]
-std = []
-
+bmp = ["bgp", "chrono"]

--- a/src/asn.rs
+++ b/src/asn.rs
@@ -6,6 +6,7 @@ use std::convert::TryInto;
 use std::str::FromStr;
 use std::iter::Peekable;
 
+#[cfg(feature = "octseq")]
 use octseq::builder::OctetsBuilder;
 
 #[cfg(feature = "bcder")]
@@ -49,6 +50,7 @@ impl Asn {
         self.0.to_be_bytes()
     }
 
+    #[cfg(feature = "octseq")]
     pub fn compose<Target: OctetsBuilder>(
         self, target: &mut Target
     ) -> Result<(), Target::AppendError> {


### PR DESCRIPTION
This PR cleans up the Cargo.toml file, and sets the versions of the dependencies to their actual minimums for successful compilation.
Checked via `cargo +nightly  update -Z minimal-versions && cargo test --all-features` .