### PR TITLE
Add cargo check+test for minimal-versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,20 @@ jobs:
         rustup component add clippy
         cargo clippy --all --all-features -- -D warnings
 
+    - if: matrix.rust == 'beta'
+      run: rustup component add clippy
     # For beta, do not error out on warnings.
     - if: matrix.rust == 'beta'
       uses: mathiasvr/command-output@v2.0.0
       id: clippy_beta
       with:
         run: |
-          rustup component add clippy
           # temporarily warn on clippy::cargo lints, to see if the next if is
           # triggered and working as expected
           cargo clippy --all --all-features -q -- -W clippy::cargo
 
-    - if: ${{ steps.clippy_beta.outputs.stderr }} != ''
-      run: echo "::warning ::${{ steps.clippy_beta.outputs.stderr }}"
+    - if: ${{ steps.clippy_beta.outputs.stderr }}
+      run: echo ::warning ::${{ steps.clippy_beta.outputs.stderr }}
 
 
     # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,24 @@ jobs:
 
     # Clippy.
     #
-    # Only do this once with all features enabled.
-    - if: matrix.rust != 'beta'
-      run: rustup component add clippy
-    - if: matrix.rust != 'beta'
-      run: cargo clippy --all --all-features -- -D warnings
+    # For stable, error out on warnings.
+    - if: matrix.rust == 'stable'
+      run: |
+        rustup component add clippy
+        cargo clippy --all --all-features -- -D warnings
+
+    # For beta, do not error out on warnings.
+    - if: matrix.rust == 'beta'
+      id: clippy_beta
+      run: |
+        rustup component add clippy
+        # temporarily warn on clippy::cargo lints, to see if the next if is
+        # triggered and working as expected
+        cargo clippy --all --all-features -q -- -W clippy::cargo
+
+    - if: ${{ clippy_beta.outputs.stderr }} != ''
+      run: echo "::warning ${{ clippy_beta.outputs.stderr }}"
+
 
     # Build
     - run: cargo build --verbose --all --all-features
@@ -37,7 +50,7 @@ jobs:
     - run: cargo test --verbose --all
 
     # Test using minimal dependency versions from Cargo.toml
-    - if: matrix.rust == 'stable'
+    - if: matrix.rust != 'beta'
       run: |
         rustup toolchain install nightly
         cargo +nightly update -Z minimal-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,12 @@ jobs:
     - if: matrix.rust == 'beta'
       uses: mathiasvr/command-output@v2.0.0
       id: clippy_beta
-      run: |
-        rustup component add clippy
-        # temporarily warn on clippy::cargo lints, to see if the next if is
-        # triggered and working as expected
-        cargo clippy --all --all-features -q -- -W clippy::cargo
+      with:
+        run: |
+          rustup component add clippy
+          # temporarily warn on clippy::cargo lints, to see if the next if is
+          # triggered and working as expected
+          cargo clippy --all --all-features -q -- -W clippy::cargo
 
     - if: ${{ steps.clippy_beta.outputs.stderr }} != ''
       run: echo "::warning ::${{ steps.clippy_beta.outputs.stderr }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [1.71, stable, beta, nightly]
+        rust: [1.71, stable, beta]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
@@ -37,9 +37,9 @@ jobs:
     - run: cargo test --verbose --all
 
     # Test using minimal dependency versions from Cargo.toml
-    - if: matrix.rust == 'nightly'
+    - if: matrix.rust == 'stable'
       run: |
         cargo +nightly update -Z minimal-versions
-        cargo check --all-features --verbose --all-targets
-        cargo test --all-features
+        cargo build --verbose --all --all-features
+        cargo test --verbose --all --all-features
       name: Check and test with minimal-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,36 +16,40 @@ jobs:
         with:
           rust-version: ${{ matrix.rust }}
 
-      # Because of all the features, we run build and test twice -- once with
-      # full features and once without any features at all -- to make it more
-      # likely that everything works.
-
       # Clippy.
+      #
+      # We run Clippy for stable and beta only, to minimize the possibility of a
+      # lint requiring something in the MSRV but the opposite thing in stable,
+      # or vice versa.
       #
       # For stable, error out on warnings.
       - if: matrix.rust == 'stable'
         run: |
           rustup component add clippy
-          cargo clippy --all --all-features -- -D warnings
+          cargo clippy --all --all-features -- -D warnings -W clippy::cargo
 
       - if: matrix.rust == 'beta'
         run: rustup component add clippy
 
-      # For beta, do not error out on warnings.
+      # For beta, turn warnings into GitHub annotations.
       - if: matrix.rust == 'beta'
         uses: mathiasvr/command-output@v2.0.0
         id: clippy_beta
         with:
           run: |
-            # temporarily warn on clippy::cargo lints, to see if the next if is
-            # triggered and working as expected
-            cargo clippy --all --all-features -q -- -W clippy::cargo
+            # We can warn on additional lints. cargo::nursery might make sense.
+            cargo clippy --all --all-features -q --message-format short -- \
+            -W clippy::cargo # -W clippy::nursery
 
       - if: ${{ steps.clippy_beta.outputs.stderr }}
         env:
           clippy_warnings: ${{ steps.clippy_beta.outputs.stderr }}
         run: echo "::warning ::$clippy_warnings"
 
+
+      # Because of all the features, we run build and test twice -- once with
+      # full features and once without any features at all -- to make it more
+      # likely that everything works.
 
       # Build
       - run: cargo build --verbose --all --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,10 @@ jobs:
     - run: cargo test --verbose --all --all-features
     - run: cargo test --verbose --all
 
+    # Test using minimal dependency versions from Cargo.toml
+    - if: matrix.rust == 'nightly'
+      run: |
+        cargo +nightly update -Z minimal-versions
+        cargo check --all-features --verbose --all-targets
+        cargo test --all-features
+      name: Check and test with minimal-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
         # triggered and working as expected
         cargo clippy --all --all-features -q -- -W clippy::cargo
 
-    - if: ${{ clippy_beta.outputs.stderr }} != ''
-      run: echo "::warning ${{ clippy_beta.outputs.stderr }}"
+    - if: ${{ steps.clippy_beta.outputs.stderr }} != ''
+      run: echo "::warning ${{ steps.clippy_beta.outputs.stderr }}"
 
 
     # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,16 @@ jobs:
 
     # For beta, do not error out on warnings.
     - if: matrix.rust == 'beta'
+      uses: mathiasvr/command-output@v2.0.0
       id: clippy_beta
       run: |
         rustup component add clippy
         # temporarily warn on clippy::cargo lints, to see if the next if is
         # triggered and working as expected
-        echo "warnings=$(cargo clippy --all --all-features -q -- -W clippy::cargo 2>&1)" >> "$GITHUB_OUTPUT"
+        cargo clippy --all --all-features -q -- -W clippy::cargo
 
-    - if: ${{ steps.clippy_beta.outputs.warnings }} != ''
-      run: echo "::warning ::${{ steps.clippy_beta.outputs.warnings }}"
+    - if: ${{ steps.clippy_beta.outputs.stderr }} != ''
+      run: echo "::warning ::${{ steps.clippy_beta.outputs.stderr }}"
 
 
     # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
           cargo clippy --all --all-features -q -- -W clippy::cargo
 
     - if: ${{ steps.clippy_beta.outputs.stderr }}
-      run: echo "::warning ::${{ steps.clippy_beta.outputs.stderr }}"
+      env:
+        clippy_warnings: ${{ steps.clippy_beta.outputs.stderr }}
+      run: echo "::warning ::$clippy_warnings"
 
 
     # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         rustup component add clippy
         # temporarily warn on clippy::cargo lints, to see if the next if is
         # triggered and working as expected
-        echo "warnings=$(cargo clippy --all --all-features -q -- -W clippy::cargo)" >> "$GITHUB_OUTPUT"
+        echo "warnings=$(cargo clippy --all --all-features -q -- -W clippy::cargo 2>&1)" >> "$GITHUB_OUTPUT"
 
     - if: ${{ steps.clippy_beta.outputs.warnings }} != ''
       run: echo "::warning ::${{ steps.clippy_beta.outputs.warnings }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     # Test using minimal dependency versions from Cargo.toml
     - if: matrix.rust == 'stable'
       run: |
+        rustup toolchain install nightly
         cargo +nightly update -Z minimal-versions
         cargo build --verbose --all --all-features
         cargo test --verbose --all --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,14 @@ jobs:
         rustup component add clippy
         # temporarily warn on clippy::cargo lints, to see if the next if is
         # triggered and working as expected
-        cargo clippy --all --all-features -q -- -W clippy::cargo
+        {
+          echo 'warnings=<<EOF'
+          cargo clippy --all --all-features -q -- -W clippy::cargo
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
 
-    - if: ${{ steps.clippy_beta.outputs.stderr }} != ''
-      run: echo "::warning ${{ steps.clippy_beta.outputs.stderr }}"
+    - if: ${{ steps.clippy_beta.outputs.warnings }} != ''
+      run: echo "::warning ${{ steps.clippy_beta.outputs.warnings }}"
 
 
     # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
 
     - if: matrix.rust == 'beta'
       run: rustup component add clippy
+
     # For beta, do not error out on warnings.
     - if: matrix.rust == 'beta'
       uses: mathiasvr/command-output@v2.0.0
@@ -41,7 +42,7 @@ jobs:
           cargo clippy --all --all-features -q -- -W clippy::cargo
 
     - if: ${{ steps.clippy_beta.outputs.stderr }}
-      run: echo ::warning ::${{ steps.clippy_beta.outputs.stderr }}
+      run: echo "::warning ::${{ steps.clippy_beta.outputs.stderr }}"
 
 
     # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,11 @@ jobs:
         with:
           run: |
             # We can warn on additional lints. cargo::nursery might make sense.
+            # XXX currently this only shows the first line of output. Also see
+            # https://github.com/actions/toolkit/issues/193
+            # Replacing '\n' with "%0A" might be a workaround.
             cargo clippy --all --all-features -q --message-format short -- \
-            -W clippy::cargo -W clippy::nursery
+            -W clippy::cargo # -W clippy::nursery
 
       - if: ${{ steps.clippy_beta.outputs.stderr }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           run: |
             # We can warn on additional lints. cargo::nursery might make sense.
             cargo clippy --all --all-features -q --message-format short -- \
-            -W clippy::cargo # -W clippy::nursery
+            -W clippy::cargo -W clippy::nursery
 
       - if: ${{ steps.clippy_beta.outputs.stderr }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         echo "warnings=$(cargo clippy --all --all-features -q -- -W clippy::cargo)" >> "$GITHUB_OUTPUT"
 
     - if: ${{ steps.clippy_beta.outputs.warnings }} != ''
-      run: echo "::warning ${{ steps.clippy_beta.outputs.warnings }}"
+      run: echo "::warning ::${{ steps.clippy_beta.outputs.warnings }}"
 
 
     # Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,7 @@ jobs:
         rustup component add clippy
         # temporarily warn on clippy::cargo lints, to see if the next if is
         # triggered and working as expected
-        {
-          echo 'warnings=<<EOF'
-          cargo clippy --all --all-features -q -- -W clippy::cargo
-          echo EOF
-        } >> "$GITHUB_OUTPUT"
+        echo "warnings=$(cargo clippy --all --all-features -q -- -W clippy::cargo)" >> "$GITHUB_OUTPUT"
 
     - if: ${{ steps.clippy_beta.outputs.warnings }} != ''
       run: echo "::warning ${{ steps.clippy_beta.outputs.warnings }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,57 +9,57 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [1.71, stable, beta]
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: ${{ matrix.rust }}
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
 
-    # Because of all the features, we run build and test twice -- once with
-    # full features and once without any features at all -- to make it more
-    # likely that everything works.
+      # Because of all the features, we run build and test twice -- once with
+      # full features and once without any features at all -- to make it more
+      # likely that everything works.
 
-    # Clippy.
-    #
-    # For stable, error out on warnings.
-    - if: matrix.rust == 'stable'
-      run: |
-        rustup component add clippy
-        cargo clippy --all --all-features -- -D warnings
-
-    - if: matrix.rust == 'beta'
-      run: rustup component add clippy
-
-    # For beta, do not error out on warnings.
-    - if: matrix.rust == 'beta'
-      uses: mathiasvr/command-output@v2.0.0
-      id: clippy_beta
-      with:
+      # Clippy.
+      #
+      # For stable, error out on warnings.
+      - if: matrix.rust == 'stable'
         run: |
-          # temporarily warn on clippy::cargo lints, to see if the next if is
-          # triggered and working as expected
-          cargo clippy --all --all-features -q -- -W clippy::cargo
+          rustup component add clippy
+          cargo clippy --all --all-features -- -D warnings
 
-    - if: ${{ steps.clippy_beta.outputs.stderr }}
-      env:
-        clippy_warnings: ${{ steps.clippy_beta.outputs.stderr }}
-      run: echo "::warning ::$clippy_warnings"
+      - if: matrix.rust == 'beta'
+        run: rustup component add clippy
+
+      # For beta, do not error out on warnings.
+      - if: matrix.rust == 'beta'
+        uses: mathiasvr/command-output@v2.0.0
+        id: clippy_beta
+        with:
+          run: |
+            # temporarily warn on clippy::cargo lints, to see if the next if is
+            # triggered and working as expected
+            cargo clippy --all --all-features -q -- -W clippy::cargo
+
+      - if: ${{ steps.clippy_beta.outputs.stderr }}
+        env:
+          clippy_warnings: ${{ steps.clippy_beta.outputs.stderr }}
+        run: echo "::warning ::$clippy_warnings"
 
 
-    # Build
-    - run: cargo build --verbose --all --all-features
-    - run: cargo build --verbose --all
+      # Build
+      - run: cargo build --verbose --all --all-features
+      - run: cargo build --verbose --all
 
-    # Test
-    - run: cargo test --verbose --all --all-features
-    - run: cargo test --verbose --all
+      # Test
+      - run: cargo test --verbose --all --all-features
+      - run: cargo test --verbose --all
 
-    # Test using minimal dependency versions from Cargo.toml
-    - if: matrix.rust != 'beta'
-      run: |
-        rustup toolchain install nightly
-        cargo +nightly update -Z minimal-versions
-        cargo build --verbose --all --all-features
-        cargo test --verbose --all --all-features
-      name: Check and test with minimal-versions
+      # Test using minimal dependency versions from Cargo.toml
+      - if: matrix.rust != 'beta'
+        run: |
+          rustup toolchain install nightly
+          cargo +nightly update -Z minimal-versions
+          cargo build --verbose --all --all-features
+          cargo test --verbose --all --all-features
+        name: Check and test with minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ license = "BSD-3-Clause"
 
 [dependencies]
 arbitrary   = { version = "1", optional = true, features = ["derive"] }
-bcder       = { version = "0.7", optional = true }
+bcder       = { version = "0.7.3", optional = true }
 bytes       = { version = "1", optional = true }
-chrono      = { version = "0.4.20", optional = true }
+chrono      = { version = "0.4.20", default-features = false, optional = true }
 const-str   = { version = "0.5", optional = true, features = ["case"] }
 log         = { version = "0.4.4", optional = true }
 octseq      = { version = "0.3.1", features = ["bytes"], optional = true }
 serde       = { version = "1.0.165", optional = true, features = ["derive"] }
-tokio       = { version = "1", features = ["sync", "rt"], optional = true }
+tokio       = { version = ">=1.24.2", features = ["sync", "rt"], optional = true }
 
 [dev-dependencies]
 memmap2         = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ chrono      = { version = "0.4.20", optional = true }
 const-str   = { version = "0.5", optional = true, features = ["case"] }
 log         = { version = "0.4.4", optional = true }
 octseq      = { version = "0.3.1", features = ["bytes"], optional = true }
-serde       = { version = "1.0.103", optional = true, features = ["derive"] }
+serde       = { version = "1.0.165", optional = true, features = ["derive"] }
 tokio       = { version = "1", features = ["sync", "rt"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytes       = { version = "1", optional = true }
 chrono      = { version = "0.4.20", optional = true, default-features = false }
 const-str   = { version = "0.5", optional = true, features = ["case"] }
 log         = { version = "0.4.4", optional = true }
-octseq      = { version = "0.3.1", optional = true, features = ["bytes"] }
+octseq      = { version = "0.4.0", optional = true, features = ["bytes"] }
 serde       = { version = "1.0.165", optional = true, features = ["derive"] }
 tokio       = { version = ">=1.24.2", optional = true, features = ["sync", "rt"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde       = { version = "1.0.165", optional = true, features = ["derive"] }
 tokio       = { version = ">=1.24.2", optional = true, features = ["sync", "rt"] }
 
 [dev-dependencies]
-memmap2         = "0.6"
+memmap2         = "0.9"
 serde_test      = "1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
 
 [dependencies]
-# Optional dependencies which, if included, introduce additional functionality.
-arbitrary = { version = "1", optional = true, features = ["derive"] }
-#bcder = { version = "0.7", optional = true }
+arbitrary   = { version = "1", optional = true, features = ["derive"] }
+bcder       = { version = "0.7", optional = true }
 bytes       = { version = "1", optional = true }
 chrono      = { version = "0.4.20", optional = true }
 const-str   = { version = "0.5", optional = true, features = ["case"] }
@@ -23,8 +22,8 @@ serde       = { version = "1.0.103", optional = true, features = ["derive"] }
 tokio       = { version = "1", features = ["sync", "rt"], optional = true }
 
 [dev-dependencies]
-serde_test      = "1.0"
 memmap2         = "0.6"
+serde_test      = "1"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ license = "BSD-3-Clause"
 arbitrary   = { version = "1", optional = true, features = ["derive"] }
 bcder       = { version = "0.7.3", optional = true }
 bytes       = { version = "1", optional = true }
-chrono      = { version = "0.4.20", default-features = false, optional = true }
+chrono      = { version = "0.4.20", optional = true, default-features = false }
 const-str   = { version = "0.5", optional = true, features = ["case"] }
 log         = { version = "0.4.4", optional = true }
-octseq      = { version = "0.3.1", features = ["bytes"], optional = true }
+octseq      = { version = "0.3.1", optional = true, features = ["bytes"] }
 serde       = { version = "1.0.165", optional = true, features = ["derive"] }
-tokio       = { version = ">=1.24.2", features = ["sync", "rt"], optional = true }
+tokio       = { version = ">=1.24.2", optional = true, features = ["sync", "rt"] }
 
 [dev-dependencies]
 memmap2         = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 categories = ["network-programming"]
 description = "A Library with Building Blocks for BGP Routing"
 documentation = "https://docs.rs/routecore/"
+repository = "https://github.com/NLnetLabs/routecore"
 edition = "2021"
 rust-version = "1.71"
 keywords = ["routing", "bgp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,28 +11,22 @@ keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
 
 [dependencies]
-
 # Optional dependencies which, if included, introduce additional functionality.
 arbitrary = { version = "1", optional = true, features = ["derive"] }
-bcder = { version = "0.7.0", optional = true }
-serde = { version = "1.0.95", optional = true, features = ["derive"] }
-
-
-bytes = { version = "1.1.0", optional = true }
-chrono = { version = "0.4", optional = true }
-const-str = { version = "0.5.3", optional = true, features = ["case"] }
-log = { version = "0.4.17", optional = true }
-
-octseq = { version = "0.3.1", features = ["bytes"], optional = true }
-tokio = { version = "1", features = ["sync", "rt"], optional = true }
+#bcder = { version = "0.7", optional = true }
+bytes       = { version = "1", optional = true }
+chrono      = { version = "0.4.20", optional = true }
+const-str   = { version = "0.5", optional = true, features = ["case"] }
+log         = { version = "0.4.4", optional = true }
+octseq      = { version = "0.3.1", features = ["bytes"], optional = true }
+serde       = { version = "1.0.103", optional = true, features = ["derive"] }
+tokio       = { version = "1", features = ["sync", "rt"], optional = true }
 
 [dev-dependencies]
 serde_test      = "1.0"
 memmap2         = "0.6"
 
 [features]
-default = ["octseq"]
+default = []
 bgp = ["bytes", "log", "octseq", "const-str"]
-bmp = ["bgp", "bytes", "chrono", "log", "octseq"]
-std = []
-
+bmp = ["bgp", "chrono"]

--- a/src/asn.rs
+++ b/src/asn.rs
@@ -6,6 +6,7 @@ use std::convert::TryInto;
 use std::str::FromStr;
 use std::iter::Peekable;
 
+#[cfg(feature = "octseq")]
 use octseq::builder::OctetsBuilder;
 
 #[cfg(feature = "bcder")]
@@ -49,6 +50,7 @@ impl Asn {
         self.0.to_be_bytes()
     }
 
+    #[cfg(feature = "octseq")]
     pub fn compose<Target: OctetsBuilder>(
         self, target: &mut Target
     ) -> Result<(), Target::AppendError> {

--- a/src/flowspec.rs
+++ b/src/flowspec.rs
@@ -23,11 +23,17 @@ impl NumericOp {
     pub fn end_of_list(&self) -> bool {
         self.0 & 0x80 == 0x80
     }
+
     pub fn and(&self) -> bool {
         self.0 & 0x40 == 0x40
     }
+
     pub fn length(&self) -> usize {
         op_to_len(self.0)
+    }
+
+    pub fn value(&self) -> u64 {
+        self.1
     }
 }
 
@@ -35,6 +41,10 @@ pub struct BitmaskOp(u8, u64);
 impl BitmaskOp {
     pub fn end_of_list(&self) -> bool {
         self.0 & 0x80 == 0x80
+    }
+
+    pub fn value(&self) -> u64 {
+        self.1
     }
 }
 


### PR DESCRIPTION
This PR adds a CI job testing whether the minimal versions as specified in Cargo.toml actually compile and pass the unit tests.