### PR TITLE
Iterators for creating RouteWorkshops from updates

### DIFF
--- a/src/bgp/message/nlri.rs
+++ b/src/bgp/message/nlri.rs
@@ -1,3 +1,4 @@
+use crate::bgp::nlri::afisafi::{AfiSafiNlri, Ipv6UnicastNlri};
 use crate::bgp::types::{Afi, AfiSafi, NextHop};
 
 use crate::addr::Prefix;
@@ -6,7 +7,7 @@ use crate::util::parser::{parse_ipv4addr, parse_ipv6addr, ParseError};
 use crate::bgp::message::update::SessionConfig;
 use crate::flowspec::Component;
 use crate::typeenum;
-use octseq::{Octets, OctetsBuilder, OctetsFrom, Parser};
+use octseq::{Octets, OctetsBuilder, OctetsFrom, OctetsInto, Parser};
 use log::debug;
 
 use std::fmt;
@@ -16,6 +17,8 @@ use std::str::FromStr;
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
 
+use crate::bgp::nlri::afisafi::AfiSafi as AfiSafiTrait;
+use crate::bgp::nlri::afisafi::IsPrefix;
 
 //------------ FixedNlriIter -------------------------------------------------
 //

--- a/src/bgp/message/update.rs
+++ b/src/bgp/message/update.rs
@@ -186,18 +186,13 @@ impl<Octs: Octets> UpdateMessage<Octs> {
     /// unicast NLRI, they might include ADD-PATH Path IDs or not.
     /// Once we switch over to the new AfiSafiType enum, we can signal PathId
     /// presence/absence.
-    pub fn afi_safis(&self) -> (
-        Option<AfiSafi>,
-        Option<AfiSafi>,
-        Option<AfiSafi>,
-        Option<AfiSafi>,
-    ) {
-        (
+    pub fn afi_safis(&self) -> [Option<AfiSafi>; 4] {
+        [
             (!self.withdrawals.is_empty()).then_some(AfiSafi::Ipv4Unicast),
             (!self.announcements.is_empty()).then_some(AfiSafi::Ipv4Unicast),
             self.mp_withdrawals().ok().flatten().map(|a| a.afi_safi()),
             self.mp_announcements().ok().flatten().map(|a| a.afi_safi()),
-        )
+        ]
     }
 
     /// Returns the conventional withdrawals.

--- a/src/bgp/nlri/afisafi.rs
+++ b/src/bgp/nlri/afisafi.rs
@@ -849,12 +849,22 @@ where
     P: Octets<Range<'a> = O>,
     ASP: AfiSafiParse<'a, O, P>
 {
-    fn new(parser: Parser<'a, P>) -> Self {
+    pub fn new(parser: Parser<'a, P>) -> Self {
         NlriIter {
             parser,
             asp: std::marker::PhantomData,
             output: std::marker::PhantomData
         }
+    }
+
+    pub fn map_into_vec<T, F: Fn(<ASP as AfiSafiParse<'_, O, P>>::Output) -> T>(parser: Parser<'a, P>, fmap: F) -> Vec<T> {
+        NlriIter {
+            parser,
+            asp: std::marker::PhantomData::<ASP>,
+            output: std::marker::PhantomData::<O>
+        }
+        .map(fmap)
+        .collect::<Vec<_>>()
     }
 }
 

--- a/src/bgp/nlri/mod.rs
+++ b/src/bgp/nlri/mod.rs
@@ -2,7 +2,7 @@ pub mod afisafi;
 mod common;
 
 mod evpn;
-mod flowspec;
+pub mod flowspec;
 mod mpls;
 mod mpls_vpn;
 mod routetarget;

--- a/src/bgp/types.rs
+++ b/src/bgp/types.rs
@@ -8,6 +8,8 @@ use crate::bgp::message::nlri::RouteDistinguisher;
 #[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
 
+use super::nlri::afisafi::{Ipv4UnicastNlri, Ipv6UnicastNlri, Ipv4UnicastAddpathNlri, Ipv6UnicastAddpathNlri};
+use super::nlri::afisafi::{AfiSafiParse, NlriIter};
 use super::aspath::HopPath;
 use super::path_attributes::AggregatorInfo;
 

--- a/src/bgp/workshop/afisafi_nlri.rs
+++ b/src/bgp/workshop/afisafi_nlri.rs
@@ -26,7 +26,7 @@ pub trait AfiSafiNlri<Octs>: Clone + Hash + Debug {
 pub trait HasBasicNlri {
     fn basic_nlri(&self) -> BasicNlri;
     fn make_route_with_nlri<O: Octets, M>(nlri: M, pa: &PaMap) 
-    -> RouteWorkshop<O, M> where M: AfiSafiNlri<O, Nlri = BasicNlri>;
+    -> RouteWorkshop<M> where M: AfiSafiNlri<O, Nlri = BasicNlri>;
 }
 
 
@@ -53,8 +53,8 @@ impl HasBasicNlri for Ipv4UnicastNlri {
     }
 
     fn make_route_with_nlri<O: Octets, M>(nlri: M, pa: &PaMap) 
-    -> RouteWorkshop<O, M> where M: AfiSafiNlri<O, Nlri = BasicNlri> {
-        RouteWorkshop::<O, M>::from_pa_map(nlri, pa.clone())
+    -> RouteWorkshop<M> where M: AfiSafiNlri<O, Nlri = BasicNlri> {
+        RouteWorkshop::<M>::from_pa_map(nlri, pa.clone())
     }
 }
 
@@ -108,8 +108,8 @@ impl HasBasicNlri for Ipv6UnicastNlri {
     }
 
     fn make_route_with_nlri<O: Octets, M>(nlri: M, pa: &PaMap)
-    -> RouteWorkshop<O, M> where M: AfiSafiNlri<O, Nlri = BasicNlri> {
-        RouteWorkshop::<O, M>::from_pa_map(nlri, pa.clone())
+    -> RouteWorkshop<M> where M: AfiSafiNlri<O, Nlri = BasicNlri> {
+        RouteWorkshop::<M>::from_pa_map(nlri, pa.clone())
     }
 }
 
@@ -155,8 +155,8 @@ impl HasBasicNlri for Ipv4MulticastNlri {
     }
 
     fn make_route_with_nlri<O: Octets, M>(nlri: M, pa: &PaMap)
-    -> RouteWorkshop<O, M> where M: AfiSafiNlri<O, Nlri = BasicNlri> {
-        RouteWorkshop::<O, M>::from_pa_map(nlri, pa.clone())
+    -> RouteWorkshop<M> where M: AfiSafiNlri<O, Nlri = BasicNlri> {
+        RouteWorkshop::<M>::from_pa_map(nlri, pa.clone())
     }
 }
 

--- a/src/bgp/workshop/route.rs
+++ b/src/bgp/workshop/route.rs
@@ -306,6 +306,8 @@ impl<N: Clone + Hash> WorkshopAttribute<N> for crate::bgp::types::NextHop {
 
 //------------ The Explosion -------------------------------------------------
 
+/// Create a Vec with all of the single `NLRIs` for one type of `NLRI`, as
+/// specified with the `AF` type argument.
 pub fn into_wrapped_rws_vec<
     'a,
     O: Octets,
@@ -324,6 +326,9 @@ pub fn into_wrapped_rws_vec<
     .collect::<Vec<_>>()
 }
 
+
+/// Create an iterator over all of the single NLRIs from a parser, and wrap
+/// them with a type `T`, that can contain Workshops, e.g. a Roto TypeValue.
 fn into_wrapped_rws_iter<
     'a,
     O: Octets + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod flowspec;
 
 #[cfg(feature = "bmp")]
 pub use octseq::Octets;
+pub use octseq::Parser;
 
 //--- Private modules
 


### PR DESCRIPTION
Trying to create Iterators for NLRI in a BGP update. The resulting iterator wraps all items in a type T, so that the iterator can return different types of NLRI.

The meat of this PR is in `bgp/workshop/route.rs`