### PR TITLE
enable AfiSafiType optionally coming from a field on a NLRI struct

### DIFF
--- a/src/bgp/message/update.rs
+++ b/src/bgp/message/update.rs
@@ -25,7 +25,7 @@ use crate::bgp::types::{
 };
 
 use crate::bgp::nlri::afisafi::{
-    AfiSafiNlri, AfiSafiParse, NlriIter, NlriEnumIter, Nlri, NlriType
+    AfiSafi as Saif_al_Afi, AfiSafiNlri, AfiSafiParse, Nlri, NlriEnumIter, NlriIter, NlriType
 };
 
 use crate::util::parser::ParseError;
@@ -291,7 +291,7 @@ impl<Octs: Octets> UpdateMessage<Octs> {
     where
         O: Octets,
         Octs: Octets<Range<'a> = O>,
-        ASP: AfiSafiNlri + AfiSafiParse<'a, O, Octs>
+        ASP: AfiSafiNlri + Saif_al_Afi + AfiSafiParse<'a, O, Octs>
     {
         if ASP::afi_safi() == AfiSafi::Ipv4Unicast && !self.withdrawals.is_empty() {
             return Ok(Some(NlriIter::<_, _, ASP>::new(
@@ -442,7 +442,7 @@ impl<Octs: Octets> UpdateMessage<Octs> {
     where
         O: Octets,
         Octs: Octets<Range<'a> = O>,
-        ASP: AfiSafiNlri + AfiSafiParse<'a, O, Octs>
+        ASP: AfiSafiNlri + Saif_al_Afi + AfiSafiParse<'a, O, Octs>
     {
         // If the requested announcements are of type Ipv4Unicast, and the
         // conventional announcements range is non-zero, return that.

--- a/src/bgp/nlri/afisafi.rs
+++ b/src/bgp/nlri/afisafi.rs
@@ -44,6 +44,10 @@ paste! {
         fn nlri(&self) -> Self::Nlri {
             self.1.nlri()
         }
+
+        fn afi_safi_type(&self) -> AfiSafiType {
+            <[<$nlri Nlri>]$(<$gen>)? as AfiSafi>::afi_safi()
+        }
     }
 
     impl$(<$gen>)? AfiSafi for [<$nlri AddpathNlri>]$(<$gen>)? {
@@ -475,9 +479,10 @@ pub trait IsNlri {
 }
 
 /// A type representing an NLRI for a certain AFI+SAFI.
-pub trait AfiSafiNlri: AfiSafi + IsNlri + Clone + Hash + Debug {
+pub trait AfiSafiNlri: Clone + Hash + Debug {
     type Nlri;
     fn nlri(&self) -> Self::Nlri;
+    fn afi_safi_type(&self) -> AfiSafiType;
 
     // TODO
     //fn nexthop_compatible(&self, nh: &super::nexthop::NextHop) -> bool;
@@ -590,6 +595,9 @@ impl AfiSafiNlri for Ipv4UnicastNlri {
     fn nlri(&self) -> Self::Nlri {
         self.0
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 
 impl FromStr for Ipv4UnicastNlri {
@@ -682,6 +690,9 @@ impl AfiSafiNlri for Ipv4MulticastNlri {
     fn nlri(&self) -> Self::Nlri {
         self.0
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 
 impl FromStr for Ipv4MulticastNlri {
@@ -760,6 +771,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for Ipv4MplsUnicastNlri<Octs> {
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 
 impl<'a, O, P> AfiSafiParse<'a, O, P> for Ipv4MplsUnicastNlri<O>
@@ -814,6 +828,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for Ipv4MplsVpnUnicastNlri<Octs> {
     type Nlri = MplsVpnNlri<Octs>;
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
+    }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
     }
 }
 
@@ -870,6 +887,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for Ipv4RouteTargetNlri<Octs> {
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 
 impl<'a, O, P> AfiSafiParse<'a, O, P> for Ipv4RouteTargetNlri<O>
@@ -921,6 +941,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for Ipv4FlowSpecNlri<Octs> {
     type Nlri = FlowSpecNlri<Octs>;
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
+    }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
     }
 }
 
@@ -1008,6 +1031,9 @@ impl AfiSafiNlri for Ipv6UnicastNlri {
     fn nlri(&self) -> Self::Nlri {
         self.0
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 impl FromStr for Ipv6UnicastNlri {
     type Err = &'static str;
@@ -1086,6 +1112,9 @@ impl AfiSafiNlri for Ipv6MulticastNlri {
     fn nlri(&self) -> Self::Nlri {
         self.0
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 
 impl<'a, O, P> AfiSafiParse<'a, O, P> for Ipv6MulticastNlri
@@ -1124,6 +1153,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for Ipv6MplsUnicastNlri<Octs> {
     type Nlri = MplsNlri<Octs>;
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
+    }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
     }
 }
 
@@ -1180,6 +1212,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for Ipv6MplsVpnUnicastNlri<Octs> {
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 
 impl<'a, O, P> AfiSafiParse<'a, O, P> for Ipv6MplsVpnUnicastNlri<O>
@@ -1234,6 +1269,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for Ipv6FlowSpecNlri<Octs> {
     type Nlri = FlowSpecNlri<Octs>;
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
+    }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
     }
 }
 
@@ -1318,6 +1356,9 @@ impl AfiSafiNlri for L2VpnVplsNlri {
     fn nlri(&self) -> Self::Nlri {
         self.0
     }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
+    }
 }
 
 impl<'a, O, P> AfiSafiParse<'a, O, P> for L2VpnVplsNlri
@@ -1357,6 +1398,9 @@ impl<Octs: Clone + Debug + Hash> AfiSafiNlri for L2VpnEvpnNlri<Octs> {
     type Nlri = EvpnNlri<Octs>;
     fn nlri(&self) -> Self::Nlri {
         self.0.clone()
+    }
+    fn afi_safi_type(&self) -> AfiSafiType {
+        <Self as AfiSafi>::afi_safi()
     }
 }
 

--- a/src/bgp/nlri/afisafi.rs
+++ b/src/bgp/nlri/afisafi.rs
@@ -495,7 +495,7 @@ pub trait AfiSafiParse<'a, O, P>: Sized + IsNlri
     fn parse(parser: &mut Parser<'a, P>) -> Result<Self::Output, ParseError>;
 }
 
-pub trait NlriCompose: AfiSafiNlri {
+pub trait NlriCompose: AfiSafiNlri + AfiSafi + IsNlri {
     fn compose<Target: OctetsBuilder>(&self, target: &mut Target)
         -> Result<(), Target::AppendError>;
 

--- a/src/bgp/workshop/route.rs
+++ b/src/bgp/workshop/route.rs
@@ -19,7 +19,7 @@ use crate::bgp::{
     },
 };
 
-use crate::bgp::nlri::afisafi::{AfiSafi, AfiSafiNlri, AfiSafiType, Nlri};
+use crate::bgp::nlri::afisafi::{AfiSafiNlri, AfiSafiType, Nlri};
 use crate::bgp::nlri::nexthop::NextHop;
 use crate::bgp::types::ConventionalNextHop;
 

--- a/src/bgp/workshop/route.rs
+++ b/src/bgp/workshop/route.rs
@@ -19,7 +19,7 @@ use crate::bgp::{
     },
 };
 
-use crate::bgp::nlri::afisafi::{AfiSafiNlri, AfiSafiType, Nlri};
+use crate::bgp::nlri::afisafi::{AfiSafi, AfiSafiNlri, AfiSafiType, Nlri};
 use crate::bgp::nlri::nexthop::NextHop;
 use crate::bgp::types::ConventionalNextHop;
 
@@ -126,9 +126,10 @@ impl<N: AfiSafiNlri + Clone + Debug + Hash> RouteWorkshop<N> {
     where
         for<'a> Vec<u8>: OctetsFrom<Octs::Range<'a>>,
     {
+        let afi_safi_type = nlri.afi_safi_type();
         let mut res = Self::new(nlri);
 
-        if N::afi_safi() == AfiSafiType::Ipv4Unicast &&
+        if afi_safi_type == AfiSafiType::Ipv4Unicast &&
             pdu.has_conventional_nlri()
         {
             if let Ok(Some(nh)) = pdu.conventional_next_hop() {


### PR DESCRIPTION
I can't `impl AfiSafi` and `IsNlri` for `BasicNlri`, because the relevant methods don't take `&self`:

```
pub struct BasicNlri {
    pub ty: AfiSafiType,
    pub prefix: Prefix,
    pub path_id: Option<PathId>,
}

impl routecore::bgp::nlri::afisafi::IsNlri for BasicNlri {
     fn nlri_type() -> NlriType {
         todo!()
     }   
 }

 impl routecore::bgp::nlri::afisafi::AfiSafi for BasicNlri {
     fn afi() -> routecore::bgp::types::Afi {
         todo!()
     }
     fn afi_safi() -> AfiSafiType {
         todo!()
     }
 }
```

This PR fixes that.