### PR TITLE
Release 0.5.0-rc0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routecore"
-version = "0.4.1-dev"
+version = "0.5.0-rc0"
 authors = ["NLnet Labs <routing-team@nlnetlabs.nl>"]
 categories = ["network-programming"]
 description = "A Library with Building Blocks for BGP Routing"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
-## Unreleased new version
+## 0.5.0-rc0
+
+Released 2024-05-29.
+
+TODO
 
 Breaking changes
 
@@ -7,6 +11,7 @@ New
 Bug fixes
 
 Other changes
+
 
 
 ## 0.4.0


### PR DESCRIPTION
Proper changelog will follow in rc1, the rc0 is merely to enable alignment of all the other crates.