### PR TITLE
update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routecore"
-version = "0.5.2-dev"
+version = "0.5.2"
 authors = ["NLnet Labs <routing-team@nlnetlabs.nl>"]
 categories = ["network-programming"]
 description = "A Library with Building Blocks for BGP Routing"
@@ -16,9 +16,9 @@ inetnum     = { version = "0.1.1", features = ["arbitrary", "serde"] }
 arbitrary   = { version = "1.3.1", optional = true, features = ["derive"] }
 bytes       = { version = "1.2", optional = true }
 chrono      = { version = "0.4.20", optional = true, default-features = false }
-const-str   = { version = "0.5", optional = true, features = ["case"] }
+const-str   = { version = "0.6", optional = true, features = ["case"] }
 log         = { version = "0.4.4", optional = true }
-octseq      = { version = "0.4.0", optional = true, features = ["bytes"] }
+octseq      = { version = "0.5", optional = true, features = ["bytes"] }
 paste       = { version = "1" }
 serde       = { version = "1.0.165", optional = true, features = ["derive"] }
 tokio       = { version = ">=1.24.2", optional = true, features = ["io-util", "macros", "net", "sync", "rt-multi-thread", "time"] }

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,16 @@ Other Changes
 Known limitations
 
 
+## 0.5.2
+
+
+Released 2025-04-22.
+
+New
+
+* `AsRef<u8>` impl for `OwnedPathAttributes`. This enables `rotonda-store` to
+  store these values in a RIB.
+
 
 ## 0.5.1
 


### PR DESCRIPTION
New

  * `AsRef<u8>` impl for `OwnedPathAttributes`. This enables `rotonda-store` to store these values in a RIB.
